### PR TITLE
Fix: complete sitemap with all languages

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,49 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-    <!-- English (default) -->
+    <!-- Home - English (default) -->
     <url>
         <loc>https://wombat-apps.com/</loc>
         <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/"/>
         <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/"/>
         <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/"/>
         <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/"/>
-        <lastmod>2025-12-19</lastmod>
+        <lastmod>2025-12-23</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
     </url>
 
-    <!-- Spanish -->
+    <!-- Home - Spanish -->
     <url>
         <loc>https://wombat-apps.com/es/</loc>
         <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/"/>
         <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/"/>
         <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/"/>
         <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/"/>
-        <lastmod>2025-12-19</lastmod>
+        <lastmod>2025-12-23</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
     </url>
 
-    <!-- French -->
+    <!-- Home - French -->
     <url>
         <loc>https://wombat-apps.com/fr/</loc>
         <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/"/>
         <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/"/>
         <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/"/>
         <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/"/>
-        <lastmod>2025-12-19</lastmod>
+        <lastmod>2025-12-23</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+
+    <!-- Home - Portuguese -->
+    <url>
+        <loc>https://wombat-apps.com/pt/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/"/>
+        <lastmod>2025-12-23</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+
+    <!-- Home - Filipino -->
+    <url>
+        <loc>https://wombat-apps.com/fil/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/"/>
+        <lastmod>2025-12-23</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <!-- Privacy Policy - English -->
     <url>
-        <loc>https://wombat-apps.com/privacy-policy.html</loc>
-        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy.html"/>
+        <loc>https://wombat-apps.com/privacy-policy/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy/"/>
         <lastmod>2025-12-19</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>
@@ -51,11 +87,13 @@
 
     <!-- Privacy Policy - Spanish -->
     <url>
-        <loc>https://wombat-apps.com/es/privacy-policy.html</loc>
-        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy.html"/>
+        <loc>https://wombat-apps.com/es/privacy-policy/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy/"/>
         <lastmod>2025-12-19</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>
@@ -63,11 +101,41 @@
 
     <!-- Privacy Policy - French -->
     <url>
-        <loc>https://wombat-apps.com/fr/privacy-policy.html</loc>
-        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy.html"/>
-        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy.html"/>
+        <loc>https://wombat-apps.com/fr/privacy-policy/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy/"/>
+        <lastmod>2025-12-19</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.3</priority>
+    </url>
+
+    <!-- Privacy Policy - Portuguese -->
+    <url>
+        <loc>https://wombat-apps.com/pt/privacy-policy/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy/"/>
+        <lastmod>2025-12-19</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.3</priority>
+    </url>
+
+    <!-- Privacy Policy - Filipino -->
+    <url>
+        <loc>https://wombat-apps.com/fil/privacy-policy/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://wombat-apps.com/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://wombat-apps.com/es/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://wombat-apps.com/fr/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://wombat-apps.com/pt/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="fil" href="https://wombat-apps.com/fil/privacy-policy/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://wombat-apps.com/privacy-policy/"/>
         <lastmod>2025-12-19</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>


### PR DESCRIPTION
## Summary

Complete the sitemap with all 5 supported languages and fix URL format issues.

## Changes

### Home pages
- Add pt and fil hreflang links to existing en, es, fr entries
- Add new entries for `/pt/` and `/fil/`

### Privacy Policy pages
- Add pt and fil hreflang links to existing entries
- Add new entries for `/pt/privacy-policy/` and `/fil/privacy-policy/`
- Fix URL format: `.html` → `/` (trailing slash to match Astro output)

## Before vs After

| Page | Before | After |
|------|--------|-------|
| Home | 3 URLs (en, es, fr) | 5 URLs (+ pt, fil) |
| Privacy | 3 URLs with .html | 5 URLs with trailing slash |
| Bingo | 5 URLs | 5 URLs (unchanged) |

**Total URLs**: 11 → 15

## Test plan

- [x] All URLs are valid and match Astro output structure
- [x] All hreflang links include all 5 languages

Closes #10